### PR TITLE
Improving sync between goroutines and using recurrent query in database

### DIFF
--- a/cmd/get_orders.go
+++ b/cmd/get_orders.go
@@ -2,13 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/quicktech-as/workers/models"
 
 	"github.com/jmoiron/sqlx"
 )
 
 // GetNewOrders returns new orders
-func GetNewOrders(newOrdersCh chan models.Order, db *sqlx.DB) {
+func GetNewOrders(newOrdersCh chan models.Order, db *sqlx.DB, wg *sync.WaitGroup) {
 	rows, err := db.Queryx("SELECT id, uuid, status, created_at FROM orders WHERE status = 'open'")
 	checkerr(err)
 
@@ -23,8 +25,11 @@ func GetNewOrders(newOrdersCh chan models.Order, db *sqlx.DB) {
 		db.MustExec("UPDATE orders SET status='processing' WHERE id=?", order.ID)
 		fmt.Printf("PROCESSING ORDER: %s\n", order.UUID)
 
+		wg.Add(1)
 		newOrdersCh <- order
 	}
+
+	fmt.Println("EMPTY ORDERS")
 }
 
 func checkerr(err error) {

--- a/cmd/get_orders.go
+++ b/cmd/get_orders.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"workers/models"
+	"github.com/quicktech-as/workers/models"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/cmd/process_order.go
+++ b/cmd/process_order.go
@@ -2,14 +2,17 @@ package cmd
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/quicktech-as/workers/models"
 
 	"github.com/jmoiron/sqlx"
 )
 
 // ProcessOrder process a order
-func ProcessOrder(order models.Order, db *sqlx.DB) {
+func ProcessOrder(order models.Order, db *sqlx.DB, wg *sync.WaitGroup) {
 	db.MustExec("UPDATE orders SET status='close' WHERE id=?", order.ID)
 	fmt.Printf("ORDER PROCESSED : %s\n", order.UUID)
 	fmt.Println("----------------------------------------------")
+	wg.Done()
 }

--- a/cmd/process_order.go
+++ b/cmd/process_order.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"workers/models"
+	"github.com/quicktech-as/workers/models"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/connection/conn.go
+++ b/connection/conn.go
@@ -1,6 +1,8 @@
 package connection
 
 import (
+	"os"
+
 	"github.com/jmoiron/sqlx"
 
 	// Used mysql drive on sql
@@ -16,7 +18,7 @@ var (
 // Get get mysql connection
 func Get() (*sqlx.DB, error) {
 	if DB == nil {
-		DB, err = sqlx.Connect("mysql", "root:root@tcp(192.168.99.100:3306)/workers")
+		DB, err = sqlx.Connect("mysql", os.Getenv("MYSQL_URL"))
 		if err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -1,29 +1,34 @@
 package main
 
 import (
+	"sync"
+	"time"
+
 	"github.com/quicktech-as/workers/cmd"
 	"github.com/quicktech-as/workers/connection"
 	"github.com/quicktech-as/workers/models"
 )
 
 func main() {
-	newOrdersCh := make(chan models.Order)
-
 	db, err := connection.Get()
 	if err != nil {
 		panic(err)
 	}
-
 	defer db.Close()
 
-	for {
-		cmd.GetNewOrders(newOrdersCh, db)
+	newOrdersCh := make(chan models.Order)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-		go func() {
+	go func() {
+		for {
 			select {
 			case order := <-newOrdersCh:
-				go cmd.ProcessOrder(order, db)
+				go cmd.ProcessOrder(order, db, &wg)
+			case <-time.After(time.Second * 5):
+				go cmd.GetNewOrders(newOrdersCh, db, &wg)
 			}
-		}()
-	}
+		}
+	}()
+	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"workers/cmd"
-	"workers/connection"
-	"workers/models"
+	"github.com/quicktech-as/workers/cmd"
+	"github.com/quicktech-as/workers/connection"
+	"github.com/quicktech-as/workers/models"
 )
 
 func main() {


### PR DESCRIPTION
## Main changes:
  - Seems to me that this code after process the first query, if some other orders were save the program must process they too, so I add one `counter` of 5 seconds that re-exec the query in database, and after that print `EMPTY ORDERS`;
  - Using WaitGroup between goroutines to wait finish process; 
    - The program always start with one `wg.Add(1)` that only will be done when the program receive one close sign `(Ctrl + C)`, it should assure that even if query not return results the program will continue to be executed.

## Some little changes:
  - Added full namespace to import path; when I was running this project in my $GOPATH the old import was not working;
  - Using var MYSQL_URL instead of use mysql database address hardcoded; you can do `export MYSQL_URL=root:root@tcp(192.168.99.100:3306)/workers` and will work fine;